### PR TITLE
feat: prevent accidental modal close

### DIFF
--- a/src/components/KadoIFrameModal/KadoIFrameModal.tsx
+++ b/src/components/KadoIFrameModal/KadoIFrameModal.tsx
@@ -46,6 +46,8 @@ const KadoIFrameModal = () => {
       <Modal
         isOpen={modalIsOpen}
         onRequestClose={closeModal}
+        shouldCloseOnOverlayClick={false}
+        shouldCloseOnEsc={false}
         style={customStyles}
       >
         <div className='close-container'>


### PR DESCRIPTION
If you start filling in the form to purchase tokens and then accidentally click outside of the form, or if you accidentally press Escape, the modal would close and all of your work would be lost!

This can be addressed in two ways:

1. Make it harder to accidentally close the modal. That's what this change does.
2. Change the behavior of the embedded page to save progress to localStorage, so that re-opening the modal continues where I left off.

It's probably worth doing both of these, but the second will need to be handled in a separate repository.